### PR TITLE
Add a complete example to showcase `pvw`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +139,7 @@ dependencies = [
 name = "pvw"
 version = "0.1.0"
 dependencies = [
+ "console",
  "ndarray",
  "num-bigint",
  "num-traits",
@@ -204,10 +230,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ num-traits = "0.2.17"
 rand = "0.8.5"
 thiserror = "1.0.50"
 ndarray = "0.15.6"
+console = "0.15.7"
+
+[[example]]
+name = "pvw"
+path = "examples/pvw.rs"

--- a/examples/pvw.rs
+++ b/examples/pvw.rs
@@ -1,0 +1,200 @@
+//! Implementation of PVW parameter and CRS generation using the `pvw-rs` crate.
+
+use std::{env, error::Error, process::exit};
+
+use console::style;
+use num_bigint::BigUint;
+use pvw::PvwParameters;
+use rand::rngs::OsRng;
+
+fn print_notice_and_exit(error: Option<String>) {
+    println!(
+        "{} PVW Parameter and CRS Generation",
+        style("  overview:").magenta().bold()
+    );
+    println!(
+        "{} pvw [-h] [--help] [--num_parties=<value>] [--threshold=<value>] [--dimension=<value>] [--redundancy=<value>]",
+        style("     usage:").magenta().bold()
+    );
+    println!(
+        "{} {} {} {} and {} must be at least 1, {} must be < n/2, {} must be power of 2",
+        style("constraints:").magenta().bold(),
+        style("num_parties").blue(),
+        style("threshold").blue(),
+        style("dimension").blue(),
+        style("redundancy").blue(),
+        style("threshold").blue(),
+        style("redundancy").blue(),
+    );
+    if let Some(error) = error {
+        println!("{} {}", style("     error:").red().bold(), error);
+    }
+    exit(0);
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // This executable is a command line tool which enables to specify
+    // PVW parameters for multi-receiver LWE encryption.
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    // Print the help if requested.
+    if args.contains(&"-h".to_string()) || args.contains(&"--help".to_string()) {
+        print_notice_and_exit(None)
+    }
+
+    // @todo: wait to #8 to be completed and use the new parameter set.
+    // consider the following a placeholder for now.
+    let mut num_parties = 10;
+    let mut threshold = 4;
+    let mut dimension = 4;
+    let mut redundancy = 8;
+
+    // Update the parameters depending on the arguments provided.
+    for arg in &args {
+        if arg.starts_with("--num_parties") {
+            let a: Vec<&str> = arg.rsplit('=').collect();
+            if a.len() != 2 || a[0].parse::<usize>().is_err() {
+                print_notice_and_exit(Some("Invalid `--num_parties` argument".to_string()))
+            } else {
+                num_parties = a[0].parse::<usize>()?
+            }
+        } else if arg.starts_with("--threshold") {
+            let a: Vec<&str> = arg.rsplit('=').collect();
+            if a.len() != 2 || a[0].parse::<usize>().is_err() {
+                print_notice_and_exit(Some("Invalid `--threshold` argument".to_string()))
+            } else {
+                threshold = a[0].parse::<usize>()?
+            }
+        } else if arg.starts_with("--dimension") {
+            let parts: Vec<&str> = arg.rsplit('=').collect();
+            if parts.len() != 2 || parts[0].parse::<usize>().is_err() {
+                print_notice_and_exit(Some("Invalid `--dimension` argument".to_string()))
+            } else {
+                dimension = parts[0].parse::<usize>()?
+            }
+        } else if arg.starts_with("--redundancy") {
+            let parts: Vec<&str> = arg.rsplit('=').collect();
+            if parts.len() != 2 || parts[0].parse::<usize>().is_err() {
+                print_notice_and_exit(Some("Invalid `--redundancy` argument".to_string()))
+            } else {
+                redundancy = parts[0].parse::<usize>()?
+            }
+        } else {
+            print_notice_and_exit(Some(format!("Unrecognized argument: {arg}")))
+        }
+    }
+
+    // Validate parameters
+    if num_parties == 0 || threshold == 0 || dimension == 0 || redundancy == 0 {
+        print_notice_and_exit(Some("All parameters must be nonzero".to_string()))
+    }
+    if threshold >= (num_parties + 1) / 2 {
+        print_notice_and_exit(Some(
+            "Threshold must be strictly less than half the number of parties".to_string(),
+        ))
+    }
+    if (redundancy & (redundancy - 1)) != 0 {
+        print_notice_and_exit(Some(
+            "Redundancy parameter must be a power of 2".to_string(),
+        ))
+    }
+
+    // @todo: wait to #8 to be completed and use the new parameter set.
+    // consider the following a placeholder for now.
+
+    // The parameters are within bound, let's go! Let's first display some
+    // information about the PVW setup.
+    println!("# PVW Parameter and CRS Generation");
+    println!("\tnum_parties (n) = {num_parties}");
+    println!("\tthreshold (t) = {threshold}");
+    println!("\tdimension (k) = {dimension}");
+    println!("\tredundancy (l) = {redundancy}");
+
+    // Create the modulus using the same large modulus as TRBFV for compatibility
+    // Q = 0x1FFFFFFEA0001 × 0x1FFFFFFE88001 × 0x1FFFFFFE48001
+    let mod1 = BigUint::from(0x1FFFFFFEA0001u64); // 562949951979521
+    let mod2 = BigUint::from(0x1FFFFFFE88001u64); // 562949951881217
+    let mod3 = BigUint::from(0x1FFFFFFE48001u64); // 562949951619073
+    let modulus: BigUint = &mod1 * &mod2 * &mod3;
+
+    println!("\tmodulus (q) = {} (~{} bits)", modulus, modulus.bits());
+
+    // Standard noise parameters (these would typically be chosen based on security analysis)
+    let x_s = 1.0; // Secret distribution parameter
+    let x_e1 = 1.0; // First noise distribution parameter
+    let x_e2 = 1.0; // Second noise distribution parameter
+
+    println!("\tsecret_param (χs) = {x_s}");
+    println!("\tnoise_param1 (χe1) = {x_e1}");
+    println!("\tnoise_param2 (χe2) = {x_e2}");
+
+    // Generate the PVW parameters structure
+    let params = PvwParameters::new(
+        num_parties,
+        threshold,
+        dimension,
+        redundancy,
+        modulus.clone(),
+        x_s,
+        x_e1,
+        x_e2,
+    )?;
+
+    println!("\n# Parameter Analysis");
+
+    // Compute and display the gadget vector delta
+    let delta = params.delta();
+    println!("\tgadget_delta (Δ) = {} (~{} bits)", delta, delta.bits());
+
+    // Generate and display the gadget vector
+    let gadget_vector = params.gadget_vector()?;
+    println!("\tgadget_vector (g) length = {}", gadget_vector.len());
+    println!("\tgadget_vector elements:");
+    for (i, element) in gadget_vector.iter().enumerate() {
+        println!("\t\tg[{}] = {} (~{} bits)", i, element, element.bits());
+    }
+
+    // Generate the Common Reference String (CRS)
+    println!("\n# CRS Generation");
+    let mut rng = OsRng;
+    let crs_matrix = params.generate_crs(&mut rng);
+
+    println!(
+        "\tCRS matrix A ∈ Z_q^({}×{})",
+        crs_matrix.nrows(),
+        crs_matrix.ncols()
+    );
+    println!("\tSample CRS elements:");
+    for i in 0..std::cmp::min(3, crs_matrix.nrows()) {
+        for j in 0..std::cmp::min(3, crs_matrix.ncols()) {
+            let element = &crs_matrix[(i, j)];
+            println!(
+                "\t\tA[{},{}] = {} (~{} bits)",
+                i,
+                j,
+                element,
+                element.bits()
+            );
+        }
+    }
+
+    // Display summary
+    println!("\n# Setup Complete");
+    println!("PVW parameters generated successfully");
+    println!("Gadget vector computed (Δ = {})", delta);
+    println!(
+        "CRS matrix A generated ({}×{} elements)",
+        crs_matrix.nrows(),
+        crs_matrix.ncols()
+    );
+    println!(
+        "Total CRS size: {} elements × ~{} bits each = ~{:.1} KB",
+        crs_matrix.len(),
+        modulus.bits(),
+        (crs_matrix.len() as f64 * modulus.bits() as f64) / (8.0 * 1024.0)
+    );
+
+    println!("\nReady for PVW multi-receiver encryption protocol");
+
+    Ok(())
+}


### PR DESCRIPTION
the following PR is a WIP to introduce an example similar to the `trbfv_add` to make an end-to-end execution of `pvw` in a setting with real parameters set.

this must be considered as a draft till we have the full implementation. I am going to stack things on top (parameters -> crs -> key gen -> enc -> dec) as long as they gets implemented.